### PR TITLE
feat(BUILD-4994): add link to repo

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -51,6 +51,13 @@ inputs:
     description: 'Whether to create a Port entity for the repository'
     required: false
     default: "true"
+  addLinkToPort:
+    description: 'Whether to add a link to the repository in Port'
+    required: false
+    default: "true"
+outputs:
+  repoURL:
+    description: 'The URL of the created repository'
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,8 @@ scaffold_directory="$INPUT_SCAFFOLDDIRECTORY"
 create_port_entity="$INPUT_CREATEPORTENTITY"
 branch_name="port_$port_run_id"
 git_url="$INPUT_GITHUBURL"
+repo_url="https://github.com/$org_name/$repository_name"
+add_link_to_port="$INPUT_ADDLINKTOPORT"
 
 get_access_token() {
   curl --silent --show-error --location --request POST 'https://api.getport.io/v1/auth/access_token' --header 'Content-Type: application/json' --data-raw "{
@@ -27,7 +29,7 @@ get_access_token() {
 }
 
 send_log() {
-  message=$1
+  local message=$1
   if [[ -n $port_run_id ]]; then
     curl --silent --show-error --location "https://api.getport.io/v1/actions/runs/$port_run_id/logs" \
       --header "Authorization: Bearer $access_token" \
@@ -41,12 +43,16 @@ send_log() {
 }
 
 add_link() {
-  url=$1
+  if [[ "$add_link_to_port" != "true" ]]; then
+    echo "Skipping adding link to Port"
+    return
+  fi
+  local link_url=$1
   curl --silent --show-error --request PATCH --location "https://api.getport.io/v1/actions/runs/$port_run_id" \
     --header "Authorization: Bearer $access_token" \
     --header "Content-Type: application/json" \
     --data "{
-      \"link\": \"$url\"
+      \"link\": \"$link_url\"
     }"
 }
 
@@ -113,6 +119,7 @@ apply_cookiecutter_template() {
 }
 
 push_to_repository() {
+  local default_branch="master"
   if [ -n "$monorepo_url" ] && [ -n "$scaffold_directory" ]; then
     git config user.name "GitHub Actions Bot"
     git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -120,7 +127,7 @@ push_to_repository() {
     git commit -m "Scaffolded project in $scaffold_directory"
     git push -u origin "$branch_name"
 
-    send_log "Creating pull request to merge $branch_name into master 🚢"
+    send_log "Creating pull request to merge $branch_name into $default_branch 🚢"
 
     owner=$(echo "$monorepo_url" | awk -F'/' '{print $4}')
     repo=$(echo "$monorepo_url" | awk -F'/' '{print $5}')
@@ -128,7 +135,7 @@ push_to_repository() {
     echo "Owner: $owner"
     echo "Repo: $repo"
 
-    PR_PAYLOAD=$(jq -n --arg title "Scaffolded project in $repo" --arg head "$branch_name" --arg base "master" '{
+    PR_PAYLOAD=$(jq -n --arg title "Scaffolded project in $repo" --arg head "$branch_name" --arg base "$default_branch" '{
       "title": $title,
       "head": $head,
       "base": $base
@@ -152,9 +159,10 @@ push_to_repository() {
     git config user.email "github-actions[bot]@users.noreply.github.com"
     git add .
     git commit -m "Initial commit after scaffolding"
-    git branch -M master
+    git branch -M $default_branch
     git remote add origin "https://oauth2:$github_token@github.com/$org_name/$repository_name.git"
-    git push -u origin master
+    git push -u origin $default_branch
+    add_link "$repo_url"
   fi
 }
 
@@ -175,7 +183,7 @@ main() {
   if [ -z "$monorepo_url" ] || [ -z "$scaffold_directory" ]; then
     send_log "Creating a new repository: $repository_name 🏃"
     create_repository
-    send_log "Created a new repository at https://github.com/$org_name/$repository_name 🚀"
+    send_log "New repository created: $repo_url 🚀"
   else
     send_log "Using monorepo scaffolding 🏃"
     clone_monorepo
@@ -185,10 +193,8 @@ main() {
 
   send_log "Starting templating with cookiecutter 🍪"
   apply_cookiecutter_template
-  send_log "Pushing the template into the repository ⬆️"
+  send_log "Pushing the template into the repository."
   push_to_repository
-
-  url="https://github.com/$org_name/$repository_name"
 
   if [[ "$create_port_entity" == "true" ]]; then
     send_log "Reporting to Port the new entity created 🚢"
@@ -200,8 +206,9 @@ main() {
   if [ -n "$monorepo_url" ] && [ -n "$scaffold_directory" ]; then
     send_log "Finished! 🏁✅"
   else
-    send_log "Finished! Visit $url 🏁✅"
+    send_log "Finished! Visit $repo_url 🏁✅"
   fi
+  echo "repoURL=$repo_url" >>"$GITHUB_OUTPUT"
 }
 
 main


### PR DESCRIPTION
Add `repoURL` output.
Fix shellcheck warnings.
Add an `addLinkToPort` option to allow deactivating `add_link()` while the API overwrites the existing links instead of adding to them.