### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: SonarSource/gh-action_pre-commit@2ddc0c7fdabce0adfaaa4075a17690972ed9961a # 1.2.0
         with:

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   next:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Build and run shadow scans
     permissions:
       id-token: write


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/pre-commit.yml`
- `.github/workflows/sonarqube.yaml`
- `.github/workflows/unified-dogfooding.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.
